### PR TITLE
Added a public property to be able to define the inset between the track...

### DIFF
--- a/YLProgressBar/YLProgressBar.h
+++ b/YLProgressBar/YLProgressBar.h
@@ -312,4 +312,11 @@ IB_DESIGNABLE @interface YLProgressBar : UIView
  */
 @property (nonatomic, assign) IBInspectable BOOL hideTrack;
 
+/**
+ * @abstract A CGFloat value that determines the inset between the track and 
+ * the progressBar for the rounded progress bar type. The default value is 
+ * 1px
+ */
+@property (nonatomic, assign) CGFloat progressBarInset;
+
 @end

--- a/YLProgressBar/YLProgressBar.m
+++ b/YLProgressBar/YLProgressBar.m
@@ -27,7 +27,7 @@
 #import "YLProgressBar.h"
 
 // Sizes
-const NSInteger YLProgressBarSizeInset = 1; //px
+const NSInteger YLDefaultProgressBarSizeInset = 1; //px
 
 // Animation times
 const NSTimeInterval YLProgressBarStripesAnimationTime = 1.0f / 30.0f; // s
@@ -136,10 +136,10 @@ const CGFloat YLProgressBarDefaultProgress = 0.3f;
     CGRect innerRect;
     if (_type == YLProgressBarTypeRounded)
     {
-        innerRect = CGRectMake(YLProgressBarSizeInset,
-                               YLProgressBarSizeInset,
-                               CGRectGetWidth(rect) * self.progress - 2 * YLProgressBarSizeInset,
-                               CGRectGetHeight(rect) - 2 * YLProgressBarSizeInset);
+        innerRect = CGRectMake(_progressBarInset,
+                               _progressBarInset,
+                               CGRectGetWidth(rect) * self.progress - 2 * _progressBarInset,
+                               CGRectGetHeight(rect) - 2 * _progressBarInset);
     } else
     {
         innerRect = CGRectMake(0, 0, CGRectGetWidth(rect) * self.progress, CGRectGetHeight(rect));
@@ -338,6 +338,7 @@ const CGFloat YLProgressBarDefaultProgress = 0.3f;
     self.stripesWidth             = YLProgressBarDefaultStripeWidth;
     self.stripesDelta             = YLProgressBarDefaultStripeDelta;
     self.backgroundColor          = [UIColor clearColor];
+    self.progressBarInset         = YLDefaultProgressBarSizeInset;
 }
 
 - (UIBezierPath *)stripeWithOrigin:(CGPoint)origin bounds:(CGRect)frame orientation:(YLProgressBarStripesOrientation)orientation
@@ -522,7 +523,7 @@ const CGFloat YLProgressBarDefaultProgress = 0.3f;
         
         NSInteger start = -_stripesWidth;
         NSInteger end   = rect.size.width / (2 * _stripesWidth) + (2 * _stripesWidth);
-        CGFloat yOffset = (_type == YLProgressBarTypeRounded) ? YLProgressBarSizeInset : 0;
+        CGFloat yOffset = (_type == YLProgressBarTypeRounded) ? _progressBarInset : 0;
       
         for (NSInteger i = start; i <= end; i++)
         {

--- a/YLProgressBarSample/YLViewController.h
+++ b/YLProgressBarSample/YLViewController.h
@@ -17,6 +17,7 @@
 @property (nonatomic, strong) IBOutlet YLProgressBar      *progressBarFlatAnimated;
 @property (nonatomic, strong) IBOutlet YLProgressBar      *progressBarRoundedSlim;
 @property (nonatomic, strong) IBOutlet YLProgressBar      *progressBarRoundedFat;
+@property (nonatomic, strong) IBOutlet YLProgressBar      *progressBarRoundedSlimInsetless;
 @property (nonatomic, strong) IBOutlet UISegmentedControl *colorsSegmented;
 
 #pragma mark Constructors - Initializers

--- a/YLProgressBarSample/YLViewController.m
+++ b/YLProgressBarSample/YLViewController.m
@@ -21,6 +21,7 @@
 - (void)initFlatAnimatedProgressBar;
 - (void)initRoundedSlimProgressBar;
 - (void)initRoundedFatProgressBar;
+- (void)initInsetlessRoundedProgressBar;
 
 @end
 
@@ -37,16 +38,18 @@
     [self initFlatAnimatedProgressBar];
     [self initRoundedSlimProgressBar];
     [self initRoundedFatProgressBar];
+    [self initInsetlessRoundedProgressBar];
 }
 
 - (void)viewDidUnload
 {
-    self.progressBarFlatRainbow       = nil;
-    self.progressBarFlatWithIndicator = nil;
-    self.progressBarFlatAnimated      = nil;
-    self.progressBarRoundedSlim       = nil;
-    self.progressBarRoundedFat        = nil;
-    self.colorsSegmented              = nil;
+    self.progressBarFlatRainbow             = nil;
+    self.progressBarFlatWithIndicator       = nil;
+    self.progressBarFlatAnimated            = nil;
+    self.progressBarRoundedSlim             = nil;
+    self.progressBarRoundedFat              = nil;
+    self.progressBarRoundedSlimInsetless    = nil;
+    self.colorsSegmented                    = nil;
     
     [super viewDidUnload];
 }
@@ -155,6 +158,7 @@
     [_progressBarFlatAnimated setProgress:progress animated:animated];
     [_progressBarRoundedSlim setProgress:progress animated:animated];
     [_progressBarRoundedFat setProgress:progress animated:animated];
+    [_progressBarRoundedSlimInsetless setProgress:progress animated:animated];
 }
 
 - (void)initFlatRainbowProgressBar
@@ -220,6 +224,13 @@
     _progressBarRoundedFat.stripesOrientation       = YLProgressBarStripesOrientationLeft;
     _progressBarRoundedFat.indicatorTextDisplayMode = YLProgressBarIndicatorTextDisplayModeProgress;
     _progressBarRoundedFat.indicatorTextLabel.font  = [UIFont fontWithName:@"Arial-BoldMT" size:20];
+}
+
+- (void)initInsetlessRoundedProgressBar
+{
+    _progressBarRoundedSlimInsetless.progressTintColor        = [UIColor colorWithRed:239/255.0f green:225/255.0f blue:13/255.0f alpha:1.0f];
+    _progressBarRoundedSlimInsetless.stripesColor             = [UIColor colorWithRed:0 green:0 blue:0 alpha:0.36f];
+    _progressBarRoundedSlimInsetless.progressBarInset         = 0.f;
 }
 
 @end

--- a/YLProgressBarSample/en.lproj/YLViewController_iPad.xib
+++ b/YLProgressBarSample/en.lproj/YLViewController_iPad.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.iPad.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YLViewController">
@@ -13,6 +13,7 @@
                 <outlet property="progressBarFlatWithIndicator" destination="g4I-GQ-jgW" id="K6C-L0-31w"/>
                 <outlet property="progressBarRoundedFat" destination="Aax-RT-dnT" id="VgD-8X-5ym"/>
                 <outlet property="progressBarRoundedSlim" destination="ctJ-xj-HKZ" id="F5Q-aM-yJ2"/>
+                <outlet property="progressBarRoundedSlimInsetless" destination="KWC-nM-MBU" id="rxv-Au-mEK"/>
                 <outlet property="view" destination="2" id="3"/>
             </connections>
         </placeholder>
@@ -63,6 +64,10 @@
                         <action selector="percentageButtonTapped:" destination="-1" eventType="valueChanged" id="cEh-gp-II9"/>
                     </connections>
                 </segmentedControl>
+                <view contentMode="scaleToFill" id="KWC-nM-MBU" customClass="YLProgressBar">
+                    <rect key="frame" x="20" y="734" width="728" height="12"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                </view>
             </subviews>
             <color key="backgroundColor" red="0.43529411759999997" green="0.43529411759999997" blue="0.43529411759999997" alpha="1" colorSpace="custom" customColorSpace="adobeRGB1998"/>
             <simulatedStatusBarMetrics key="simulatedStatusBarMetrics" statusBarStyle="blackOpaque"/>

--- a/YLProgressBarSample/en.lproj/YLViewController_iPhone.xib
+++ b/YLProgressBarSample/en.lproj/YLViewController_iPhone.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6246"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6247"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="YLViewController">
@@ -13,6 +13,7 @@
                 <outlet property="progressBarFlatWithIndicator" destination="Vka-3w-pJi" id="ofv-V3-lmW"/>
                 <outlet property="progressBarRoundedFat" destination="Z3Y-VD-3la" id="yu0-jx-heI"/>
                 <outlet property="progressBarRoundedSlim" destination="DRP-e9-Hpg" id="MoV-a2-VAC"/>
+                <outlet property="progressBarRoundedSlimInsetless" destination="QBh-7A-tSt" id="lpQ-vJ-g4Y"/>
                 <outlet property="view" destination="6" id="7"/>
             </connections>
         </placeholder>
@@ -85,6 +86,10 @@
                 </view>
                 <view contentMode="scaleToFill" id="Z3Y-VD-3la" customClass="YLProgressBar">
                     <rect key="frame" x="20" y="315" width="280" height="30"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                </view>
+                <view contentMode="scaleToFill" id="QBh-7A-tSt" customClass="YLProgressBar">
+                    <rect key="frame" x="20" y="371" width="280" height="12"/>
                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                 </view>
             </subviews>


### PR DESCRIPTION
... bar and the progress bar. Added an additional bar to the example view controller.

In one of my projects, I wanted to use your progress bar, and I only missed one thing: the ability to define the inset between the track bar and the progress bar. I added a new public property to be able to, and I think that this is ain improvement in terms of how much the progress bars can be customized. I'd love to see the pull request approved!

All the best,

Ivan Oliver